### PR TITLE
*: Bump golang to 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL  = /bin/bash
 
 VERSION         = v1.4.0
-BUILDER         = docker.elastic.co/beats-dev/golang-crossbuild:1.17.6-$$BUILDER_TAG-debian10
+BUILDER         = docker.elastic.co/beats-dev/golang-crossbuild:1.19-$$BUILDER_TAG-debian10
 BUILD_TARGETS   = linux/amd64 windows/amd64 darwin/amd64 darwin/arm64
 
 .PHONY: build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lopezator/sqlfmt
 
-go 1.17
+go 1.19
 
 replace (
 	github.com/abourget/teamcity => github.com/cockroachdb/teamcity v0.0.0-20180905144921-8ca25c33eb11


### PR DESCRIPTION
- Update the `go.mod` file and the Docker image to use golang 1.19.