### PR TITLE
internal/cli: add initial tests structure

### DIFF
--- a/internal/cli/sqlfmt.go
+++ b/internal/cli/sqlfmt.go
@@ -15,9 +15,7 @@
 package cli
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -102,7 +100,7 @@ func runSQLFmt(cmd *cobra.Command, args []string) error {
 			sl = append(sl, stmts...)
 		}
 	} else {
-		in, err := ioutil.ReadAll(os.Stdin)
+		in, err := ioutil.ReadAll(cmd.InOrStdin())
 		if err != nil {
 			return err
 		}
@@ -123,11 +121,11 @@ func runSQLFmt(cmd *cobra.Command, args []string) error {
 	}
 
 	for i := range sl {
-		fmt.Print(cfg.Pretty(sl[i].AST))
+		out := cfg.Pretty(sl[i].AST)
 		if len(sl) > 1 {
-			fmt.Print(";")
+			out = out + ";"
 		}
-		fmt.Println()
+		cmd.OutOrStdout().Write([]byte(out))
 	}
 	return nil
 }

--- a/internal/cli/sqlfmt_test.go
+++ b/internal/cli/sqlfmt_test.go
@@ -1,0 +1,51 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lopezator/sqlfmt/internal/cli"
+)
+
+func TestRunSQLFmt(t *testing.T) {
+	var buf = new(bytes.Buffer)
+
+	tests := map[string]struct {
+		args  []string
+		input string
+		want  string
+	}{
+		"simple": {
+			args:  []string{"--use-spaces"},
+			input: "SElect * from foo;",
+			want:  "SELECT * FROM foo",
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			sqlfmtCmd := cli.NewSqlfmtCmd()
+
+			sqlfmtCmd.SetIn(strings.NewReader(test.input))
+			sqlfmtCmd.SetOut(buf)
+			sqlfmtCmd.SetErr(buf)
+			sqlfmtCmd.SetArgs(test.args)
+
+			c, err := sqlfmtCmd.ExecuteC()
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if c.Name() != "sqlfmt" {
+				t.Errorf(`invalid command returned from ExecuteC: expected "set"', got: %q`, c.Name())
+			}
+			got := buf.String()
+
+			if test.want != got {
+				t.Errorf("Unexpected output: expected: %v, got: %v", test.want, got)
+			}
+
+			buf.Reset()
+		})
+	}
+}


### PR DESCRIPTION
- Add initial tests structure for sqlfmt.go
- Use the inputs/outputs defined by Cobra instead of the standard ones. This allows us to test the command without having to deal with the standard input/output.