### PR TITLE
sqlfmt: add flag version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SHELL  = /bin/bash
 
-VERSION         = v1.5.0
+VERSION         = v1.5.1
 BUILDER         = docker.elastic.co/beats-dev/golang-crossbuild:1.19-$$BUILDER_TAG-debian10
 BUILD_TARGETS   = linux/amd64 windows/amd64 darwin/amd64 darwin/arm64
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Flags:
       --no-simplify     Don't simplify output.
       --tab-width int   Number of spaces per indentation level. (default 4)
       --use-spaces      Indent with spaces instead of tabs.
+  -v, --version         version for sqlfmt
 ```
 
 ## Examples

--- a/internal/cli/sqlfmt.go
+++ b/internal/cli/sqlfmt.go
@@ -66,10 +66,11 @@ var sqlfmtCtx struct {
 // NewSqlfmtCmd create and returns the sqlfmt command
 func NewSqlfmtCmd() *cobra.Command {
 	sqlfmtCmd := &cobra.Command{
-		Use:   "sqlfmt",
-		Short: "format SQL statements",
-		Long:  "Formats SQL statements from stdin to line length n.",
-		RunE:  runSQLFmt,
+		Use:     "sqlfmt",
+		Version: "1.5.1",
+		Short:   "format SQL statements",
+		Long:    "Formats SQL statements from stdin to line length n.",
+		RunE:    runSQLFmt,
 	}
 
 	cfg := tree.DefaultPrettyCfg()


### PR DESCRIPTION
Now you can execute `sqlfmt -v` to know the current version.